### PR TITLE
Fix auth integration with Supabase

### DIFF
--- a/src/app/dashboard/cuenta/page.tsx
+++ b/src/app/dashboard/cuenta/page.tsx
@@ -95,8 +95,12 @@ export default function CuentaPage() {
       alert("✅ Datos actualizados correctamente.");
       router.refresh();
 
-    } catch (err: any) {
-      setError(err.message || "Ocurrió un error al guardar.");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Ocurrió un error al guardar.");
+      }
     } finally {
       setSaving(false);
     }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -30,7 +30,7 @@ export default async function DashboardLayout({
   }
 
   // ⚡️ Obtener datos del restaurante
-  const { data, error } = await supabase
+  const { data } = await supabase
     .from("restaurants")
     .select("name")
     .eq("user_id", session.user.id)

--- a/src/app/utils/supabaseClient.ts
+++ b/src/app/utils/supabaseClient.ts
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
-console.log('SUPABASE_URL:', process.env.NEXT_PUBLIC_SUPABASE_URL);
-console.log('SUPABASE_ANON_KEY:', process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
-
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+export const supabase = createClientComponentClient({
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+});

--- a/src/app/utils/supabaseServer.ts
+++ b/src/app/utils/supabaseServer.ts
@@ -1,22 +1,8 @@
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
-/**
- * Next 14 cookies() compatibility shim.
- * Emula la interfaz CookieStore para Supabase.
- */
-async function getCookiesAdapter() {
-  const cookieList = await cookies().getAll();
-
-  return {
-    get(name: string) {
-      return cookieList.find((c) => c.name === name);
-    },
-  };
-}
-
-export async function createSupabaseServerClient() {
+export function createSupabaseServerClient() {
   return createServerComponentClient({
-    cookies: getCookiesAdapter,
+    cookies,
   });
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { PanelLeft } from "lucide-react"
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/sidebar-parts.tsx
+++ b/src/components/ui/sidebar-parts.tsx
@@ -10,7 +10,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useSidebar } from "@/components/ui/sidebar"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -7,7 +7,6 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { TooltipProvider } from "@/components/ui/tooltip"
-import { HeaderBase } from "@/app/dashboard/components/header-base"
 
 export * from "./sidebar-exports"
 
@@ -48,19 +47,19 @@ export const SidebarProvider = React.forwardRef<
 >(
   (
     {
-      defaultOpen = !useIsMobile(),
+      defaultOpen,
       open: openProp,
       onOpenChange: setOpenProp,
       className,
-      style,
       children,
       ...props
     },
     ref
   ) => {
     const isMobile = useIsMobile()
+    const defaultOpenValue = defaultOpen ?? !isMobile
     const [openMobile, setOpenMobile] = React.useState(false)
-    const [_open, _setOpen] = React.useState(defaultOpen)
+    const [_open, _setOpen] = React.useState(defaultOpenValue)
     const open = openProp ?? _open
 
     const setOpen = React.useCallback(


### PR DESCRIPTION
## Summary
- wire up Supabase client to use auth-helpers so sessions persist in cookies
- simplify server Supabase client adapter
- fix typed error handling in account page
- clean up unused imports
- resolve conditional hook usage in sidebar
- run lint

## Testing
- `npm run lint`
- `npm run build` *(fails: either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!)*

------
https://chatgpt.com/codex/tasks/task_e_68681c500a3c8328845ad779117a57a9